### PR TITLE
[iOS] 달력 collection view에서 cell에서 들어가는 날짜를 관리하는 객체 구현

### DIFF
--- a/iOS/AirbnbProject/AirbnbProject.xcodeproj/project.pbxproj
+++ b/iOS/AirbnbProject/AirbnbProject.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		AB9CAE302477DA4C000CFBFC /* CountButtonManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9CAE2F2477DA4C000CFBFC /* CountButtonManager.swift */; };
 		AB9CAE32247A9E7F000CFBFC /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9CAE31247A9E7F000CFBFC /* DateExtension.swift */; };
 		AB9CAE34247A9FB2000CFBFC /* DateFomatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9CAE33247A9FB2000CFBFC /* DateFomatterExtension.swift */; };
+		ABF4CB1E247BD22F00444F72 /* CalendarCollectionViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF4CB1D247BD22F00444F72 /* CalendarCollectionViewManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +83,7 @@
 		AB9CAE2F2477DA4C000CFBFC /* CountButtonManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountButtonManager.swift; sourceTree = "<group>"; };
 		AB9CAE31247A9E7F000CFBFC /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		AB9CAE33247A9FB2000CFBFC /* DateFomatterExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFomatterExtension.swift; sourceTree = "<group>"; };
+		ABF4CB1D247BD22F00444F72 /* CalendarCollectionViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionViewManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +154,7 @@
 				6A301D2324791B5000D23B84 /* CalendarViewController.swift */,
 				6A301D25247920BC00D23B84 /* DayCollectionViewCell.swift */,
 				6A301D27247936EF00D23B84 /* MonthCollectionReusableView.swift */,
+				ABF4CB1D247BD22F00444F72 /* CalendarCollectionViewManager.swift */,
 			);
 			path = CalendarView;
 			sourceTree = "<group>";
@@ -361,6 +364,7 @@
 				6A301D26247920BC00D23B84 /* DayCollectionViewCell.swift in Sources */,
 				6A789A65247409B1005CF258 /* ThumbnailImageCollectionViewCell.swift in Sources */,
 				6A6EE0482476C90600D18488 /* FavoriteButton.swift in Sources */,
+				ABF4CB1E247BD22F00444F72 /* CalendarCollectionViewManager.swift in Sources */,
 				6A6EE04A2476CB0200D18488 /* ButtonExtension.swift in Sources */,
 				AB9CAE2824769C0C000CFBFC /* GuestFilterViewController.swift in Sources */,
 			);

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarCollectionViewManager.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarCollectionViewManager.swift
@@ -1,0 +1,40 @@
+//
+//  CalendarCollectionViewManager.swift
+//  AirbnbProject
+//
+//  Created by 임승혁 on 2020/05/25.
+//  Copyright © 2020 dev-Lena. All rights reserved.
+//
+
+import Foundation
+
+class CalenderCollectionViewManager {
+    
+    private let calendar = Calendar.init(identifier: .gregorian)
+    private let formatter = DateFormatter()
+    private let currMonth: Date
+    private let numberToAdjustFirstDay = 2
+    private let numberToAdjustNextDay = 3
+    private let firstDayPosition: Int
+    
+    let today: Int
+    
+    init(indexPath: IndexPath) {
+        self.currMonth = Calendar.current.date(byAdding: .month, value: indexPath.section, to: Date())!
+        
+        let startDate = Date().getStartDayInMonth(year: formatter.getYear(from: currMonth), month: formatter.getMonth(from: currMonth))
+        
+        let firstWeekDay = calendar.dateComponents([.weekday], from: startDate).weekday!
+        
+        self.firstDayPosition = firstWeekDay - numberToAdjustFirstDay
+        self.today = indexPath.row - firstWeekDay + numberToAdjustNextDay
+    }
+    
+    func setCellHiddenStatus(indexPath: IndexPath) -> Bool {
+        if firstDayPosition > indexPath.item {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
@@ -13,10 +13,6 @@ class CalendarViewController: UIViewController {
     @IBOutlet weak var calendarCollectionView: UICollectionView!
     
     private let numberOfSection = 12
-    private var currMonth = Date()
-    private let formatter = DateFormatter()
-    private let calendar = Calendar.init(identifier: .gregorian)
-    private var firstWeekDay: Int!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,18 +37,11 @@ extension CalendarViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DayCollectionViewCell.identifier, for: indexPath) as? DayCollectionViewCell else { return UICollectionViewCell() }
         
-        self.currMonth = Calendar.current.date(byAdding: .month, value: indexPath.section, to: Date())!
-        let startDate = Date().getStartDayInMonth(year: formatter.getYear(from: currMonth), month: formatter.getMonth(from: currMonth))
+        let manager = CalenderCollectionViewManager(indexPath: indexPath)
+        let status = manager.setCellHiddenStatus(indexPath: indexPath)
         
-        firstWeekDay = calendar.dateComponents([.weekday], from: startDate).weekday!
-        
-        if firstWeekDay - 2 > indexPath.item {
-            cell.isHidden = true
-        } else {
-            cell.isHidden = false
-            let calcDate = indexPath.row - firstWeekDay + 3
-            cell.dayLabel.text = "\(calcDate)"
-        }
+        cell.isHidden = status
+        cell.dayLabel.text = "\(manager.today)"
         
         return cell
     }


### PR DESCRIPTION
## 구현한 것.
- 기존 extension에서 기능하던 동작을 CollectionViewManager에서 기능하도록 변경

## 구현해야할 것.
- 월마다 일수를 계산해 각 section에 들어가는 cell의 개수를 조절할 수 있도록 기능 추가.
- section header의 월, 년일자(ex. April 2020)에 맞게 보여질 수 있도록 기능 추가.