### PR TITLE
[iOS] 스크롤 뷰 위치 조정 관련 로직 수정

### DIFF
--- a/iOS/AirbnbProject/AirbnbProject/Base.lproj/Main.storyboard
+++ b/iOS/AirbnbProject/AirbnbProject/Base.lproj/Main.storyboard
@@ -331,7 +331,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view alpha="0.64999997615814209" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3BC-kh-6Y9" userLabel="Dim View">
+                            <view alpha="0.65000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3BC-kh-6Y9" userLabel="Dim View">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
@@ -404,7 +404,7 @@
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Z8q-MA-Cng" secondAttribute="height" multiplier="1:0.9" id="psU-cy-eav"/>
                                                 </constraints>
-                                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="7Lv-lC-S38">
+                                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="7Lv-lC-S38">
                                                     <size key="itemSize" width="53" height="54"/>
                                                     <size key="headerReferenceSize" width="50" height="50"/>
                                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
@@ -447,6 +447,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
+                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="trailing" secondItem="EAt-eY-38L" secondAttribute="trailing" id="ED9-YN-aI2"/>
                                                         <constraint firstItem="EAt-eY-38L" firstAttribute="leading" secondItem="VSR-tH-aAR" secondAttribute="leading" constant="5" id="VHI-sQ-YvH"/>
@@ -486,7 +487,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="3BC-kh-6Y9" firstAttribute="bottom" secondItem="zlh-AR-jkL" secondAttribute="bottom" id="0AD-H9-SRY"/>
                             <constraint firstItem="L3t-jO-7SV" firstAttribute="centerY" secondItem="zlh-AR-jkL" secondAttribute="centerY" multiplier="0.95" id="Gcy-2X-yns"/>

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarCollectionViewManager.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarCollectionViewManager.swift
@@ -16,25 +16,38 @@ class CalenderCollectionViewManager {
     private let numberToAdjustFirstDay = 2
     private let numberToAdjustNextDay = 3
     private let firstDayPosition: Int
+    private var firstWeekDay: Int
+    private let dayCount: Int
     
-    let today: Int
-    
-    init(indexPath: IndexPath) {
-        self.currMonth = Calendar.current.date(byAdding: .month, value: indexPath.section, to: Date())!
-        
+    init(section: Int) {
+        self.currMonth = Calendar.current.date(byAdding: .month, value: section, to: Date())!
         let startDate = Date().getStartDayInMonth(year: formatter.getYear(from: currMonth), month: formatter.getMonth(from: currMonth))
         
-        let firstWeekDay = calendar.dateComponents([.weekday], from: startDate).weekday!
-        
+        self.firstWeekDay = calendar.dateComponents([.year, .month, .weekday], from: startDate).weekday!
+        if firstWeekDay == 1 {
+            self.firstWeekDay = 8
+        }
         self.firstDayPosition = firstWeekDay - numberToAdjustFirstDay
-        self.today = indexPath.row - firstWeekDay + numberToAdjustNextDay
+        
+        self.dayCount = (Calendar.current.range(of: .day, in: .month, for: currMonth)?.count)!
     }
     
-    func setCellHiddenStatus(indexPath: IndexPath) -> Bool {
-        if firstDayPosition > indexPath.item {
+    func setCellHiddenStatus(row : Int) -> Bool {
+        if firstDayPosition > row || dayCount + firstDayPosition <= row {
             return true
         } else {
             return false
         }
+    }
+    
+    func setCellday(row: Int) -> String {
+        return String(row - self.firstWeekDay + numberToAdjustNextDay)
+    }
+    
+    func setSectionHeaderLabel() -> String {
+        let year = formatter.getYear(from: currMonth)
+        let month = formatter.getMonthAsString(from: currMonth)
+        
+        return "\(month) \(year)"
     }
 }

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
@@ -13,6 +13,8 @@ class CalendarViewController: UIViewController {
     @IBOutlet weak var calendarCollectionView: UICollectionView!
     
     private let numberOfSection = 12
+    private var cellSize: CGFloat?
+    private var sectionHeaderHeight: CGFloat?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -31,17 +33,17 @@ extension CalendarViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 36
+        return 42
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DayCollectionViewCell.identifier, for: indexPath) as? DayCollectionViewCell else { return UICollectionViewCell() }
         
-        let manager = CalenderCollectionViewManager(indexPath: indexPath)
-        let status = manager.setCellHiddenStatus(indexPath: indexPath)
+        let manager = CalenderCollectionViewManager(section: indexPath.section)
+        let status = manager.setCellHiddenStatus(row: indexPath.row)
         
         cell.isHidden = status
-        cell.dayLabel.text = "\(manager.today)"
+        cell.dayLabel.text = "\(manager.setCellday(row: indexPath.row))"
         
         return cell
     }
@@ -49,7 +51,8 @@ extension CalendarViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind , withReuseIdentifier: MonthCollectionReusableView.identifier, for: indexPath) as? MonthCollectionReusableView else { return UICollectionReusableView() }
         
-        header.monthYearLabel.text = "April 2020"
+        let manager = CalenderCollectionViewManager(section: indexPath.section)
+        header.monthYearLabel.text = manager.setSectionHeaderLabel()
         
         return header
     }
@@ -57,13 +60,33 @@ extension CalendarViewController: UICollectionViewDataSource {
 
 extension CalendarViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let size = calendarCollectionView.frame.size.width / 9
-        let sizeForItem = CGSize(width: size, height: size)
+        //self.cellSize = calendarCollectionView.frame.size.width / 7.05
+        let sizeForItem = CGSize(width: cellSize!, height: cellSize!)
         return sizeForItem
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        let headerSize = CGSize(width:  calendarCollectionView.frame.size.width, height: calendarCollectionView.frame.size.width / 10)
+        //self.sectionHeaderHeight = calendarCollectionView.frame.size.width / 10
+        let headerSize = CGSize(width:  calendarCollectionView.frame.size.width, height: sectionHeaderHeight!)
         return headerSize
+    }
+}
+
+extension CalendarViewController: UIScrollViewDelegate, UICollectionViewDelegate {
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+
+        let sectionHeight = cellSize! * 6 + sectionHeaderHeight!
+        
+        var offset = targetContentOffset.pointee
+        let index = (offset.y + scrollView.contentInset.bottom) / sectionHeight
+        let roundedIndex = round(index)
+        
+        offset = CGPoint(x: scrollView.contentInset.top, y: roundedIndex * sectionHeight)
+        
+        DispatchQueue.main.async {
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn, animations: {
+                scrollView.setContentOffset(offset, animated: false)
+            }, completion: nil)
+        }
     }
 }

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
@@ -60,13 +60,13 @@ extension CalendarViewController: UICollectionViewDataSource {
 
 extension CalendarViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        //self.cellSize = calendarCollectionView.frame.size.width / 7.05
+        self.cellSize = calendarCollectionView.frame.size.width / 7.05
         let sizeForItem = CGSize(width: cellSize!, height: cellSize!)
         return sizeForItem
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        //self.sectionHeaderHeight = calendarCollectionView.frame.size.width / 10
+        self.sectionHeaderHeight = calendarCollectionView.frame.size.width / 10
         let headerSize = CGSize(width:  calendarCollectionView.frame.size.width, height: sectionHeaderHeight!)
         return headerSize
     }

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/DayCollectionViewCell.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/DayCollectionViewCell.swift
@@ -13,4 +13,11 @@ class DayCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var dayLabel: UILabel!
     
     static let identifier = "DayCollectionViewCell"
+    var dateInfo: CellDateInfo?
+}
+
+struct CellDateInfo {
+    let year: Int
+    let month: Int
+    let day: Int
 }

--- a/iOS/AirbnbProject/AirbnbProject/View/Extension/DateFomatterExtension.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/Extension/DateFomatterExtension.swift
@@ -18,4 +18,9 @@ extension DateFormatter {
         self.dateFormat = "MM"
         return Int(self.string(from: from))!
     }
+    
+    func getMonthAsString(from: Date) -> String {
+        self.dateFormat = "MMMM"
+        return self.string(from: from)
+    }
 }


### PR DESCRIPTION
1. section header에 month, year를 연동하여 이번 달부터 1년 까지 나타내도록 함.
ex) May 2020

2. 달력(section)별로 스크롤시 스크롤 위치가 어긋나는 문제가 발생하여 cell size의 높이, section header height를 계산하여 스크롤시 뷰를 멈추는 좌표를 계산하여 설정해주도록 함.