### PR TITLE
[iOS] 캘린더 날짜 선택

### DIFF
--- a/iOS/AirbnbProject/AirbnbProject/Assets.xcassets/faintLightGray.colorset/Contents.json
+++ b/iOS/AirbnbProject/AirbnbProject/Assets.xcassets/faintLightGray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xF8",
+          "red" : "0xF8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/AirbnbProject/AirbnbProject/Base.lproj/Main.storyboard
+++ b/iOS/AirbnbProject/AirbnbProject/Base.lproj/Main.storyboard
@@ -404,27 +404,40 @@
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Z8q-MA-Cng" secondAttribute="height" multiplier="1:0.9" id="psU-cy-eav"/>
                                                 </constraints>
-                                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="7Lv-lC-S38">
+                                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="7Lv-lC-S38">
                                                     <size key="itemSize" width="53" height="54"/>
                                                     <size key="headerReferenceSize" width="50" height="50"/>
                                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                 </collectionViewFlowLayout>
                                                 <cells>
-                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DayCollectionViewCell" id="DNG-Q0-piG" customClass="DayCollectionViewCell" customModule="AirbnbProject" customModuleProvider="target">
+                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" reuseIdentifier="DayCollectionViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="DNG-Q0-piG" customClass="DayCollectionViewCell" customModule="AirbnbProject" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="50" width="53" height="54"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="JL3-ZT-tNU">
                                                             <rect key="frame" x="0.0" y="0.0" width="53" height="54"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
+                                                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="QOF-og-lSW">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="53" height="54"/>
+                                                                    <subviews>
+                                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KJr-IJ-mDV" userLabel="leftView">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="26.5" height="54"/>
+                                                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                                        </view>
+                                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7y5-PP-lOc" userLabel="rightView">
+                                                                            <rect key="frame" x="26.5" y="0.0" width="26.5" height="54"/>
+                                                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                                        </view>
+                                                                    </subviews>
+                                                                </stackView>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mdU-Cf-bpd" userLabel="Backbround View">
                                                                     <rect key="frame" x="0.0" y="0.0" width="53" height="54"/>
                                                                     <userDefinedRuntimeAttributes>
                                                                         <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
                                                                             <real key="value" value="0.0"/>
                                                                         </userDefinedRuntimeAttribute>
-                                                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isCircle" value="YES"/>
+                                                                        
                                                                     </userDefinedRuntimeAttributes>
                                                                 </view>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ysr-34-rEo">
@@ -436,17 +449,23 @@
                                                             </subviews>
                                                             <constraints>
                                                                 <constraint firstAttribute="bottom" secondItem="mdU-Cf-bpd" secondAttribute="bottom" id="3Ej-ud-6Lg"/>
+                                                                <constraint firstAttribute="bottom" secondItem="QOF-og-lSW" secondAttribute="bottom" id="GIz-MJ-mI2"/>
                                                                 <constraint firstAttribute="trailing" secondItem="mdU-Cf-bpd" secondAttribute="trailing" id="Ihu-lv-T5G"/>
                                                                 <constraint firstItem="ysr-34-rEo" firstAttribute="centerX" secondItem="JL3-ZT-tNU" secondAttribute="centerX" id="Jam-Da-ovN"/>
                                                                 <constraint firstItem="mdU-Cf-bpd" firstAttribute="leading" secondItem="JL3-ZT-tNU" secondAttribute="leading" id="RbX-VE-35L"/>
+                                                                <constraint firstItem="QOF-og-lSW" firstAttribute="top" secondItem="JL3-ZT-tNU" secondAttribute="top" id="T07-md-UGd"/>
+                                                                <constraint firstAttribute="trailing" secondItem="QOF-og-lSW" secondAttribute="trailing" id="ZX5-B1-tHm"/>
                                                                 <constraint firstItem="ysr-34-rEo" firstAttribute="centerY" secondItem="JL3-ZT-tNU" secondAttribute="centerY" id="dRd-Yu-wci"/>
                                                                 <constraint firstItem="mdU-Cf-bpd" firstAttribute="top" secondItem="JL3-ZT-tNU" secondAttribute="top" id="slo-in-9Wd"/>
+                                                                <constraint firstItem="QOF-og-lSW" firstAttribute="leading" secondItem="JL3-ZT-tNU" secondAttribute="leading" id="xLd-Qi-kVY"/>
                                                             </constraints>
                                                         </collectionViewCellContentView>
                                                         <size key="customSize" width="53" height="54"/>
                                                         <connections>
                                                             <outlet property="cellBackgroundView" destination="mdU-Cf-bpd" id="jVe-hD-net"/>
                                                             <outlet property="dayLabel" destination="ysr-34-rEo" id="Xu7-Xr-mBb"/>
+                                                            <outlet property="leftBackgroundView" destination="KJr-IJ-mDV" id="lCU-3v-CpV"/>
+                                                            <outlet property="rightBackgroundView" destination="7y5-PP-lOc" id="gO5-iI-JHV"/>
                                                         </connections>
                                                     </collectionViewCell>
                                                 </cells>

--- a/iOS/AirbnbProject/AirbnbProject/Base.lproj/Main.storyboard
+++ b/iOS/AirbnbProject/AirbnbProject/Base.lproj/Main.storyboard
@@ -418,6 +418,15 @@
                                                             <rect key="frame" x="0.0" y="0.0" width="53" height="54"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
+                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mdU-Cf-bpd" userLabel="Backbround View">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="53" height="54"/>
+                                                                    <userDefinedRuntimeAttributes>
+                                                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                            <real key="value" value="0.0"/>
+                                                                        </userDefinedRuntimeAttribute>
+                                                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isCircle" value="YES"/>
+                                                                    </userDefinedRuntimeAttributes>
+                                                                </view>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ysr-34-rEo">
                                                                     <rect key="frame" x="11" y="20" width="31" height="14.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -426,12 +435,17 @@
                                                                 </label>
                                                             </subviews>
                                                             <constraints>
+                                                                <constraint firstAttribute="bottom" secondItem="mdU-Cf-bpd" secondAttribute="bottom" id="3Ej-ud-6Lg"/>
+                                                                <constraint firstAttribute="trailing" secondItem="mdU-Cf-bpd" secondAttribute="trailing" id="Ihu-lv-T5G"/>
                                                                 <constraint firstItem="ysr-34-rEo" firstAttribute="centerX" secondItem="JL3-ZT-tNU" secondAttribute="centerX" id="Jam-Da-ovN"/>
+                                                                <constraint firstItem="mdU-Cf-bpd" firstAttribute="leading" secondItem="JL3-ZT-tNU" secondAttribute="leading" id="RbX-VE-35L"/>
                                                                 <constraint firstItem="ysr-34-rEo" firstAttribute="centerY" secondItem="JL3-ZT-tNU" secondAttribute="centerY" id="dRd-Yu-wci"/>
+                                                                <constraint firstItem="mdU-Cf-bpd" firstAttribute="top" secondItem="JL3-ZT-tNU" secondAttribute="top" id="slo-in-9Wd"/>
                                                             </constraints>
                                                         </collectionViewCellContentView>
                                                         <size key="customSize" width="53" height="54"/>
                                                         <connections>
+                                                            <outlet property="cellBackgroundView" destination="mdU-Cf-bpd" id="jVe-hD-net"/>
                                                             <outlet property="dayLabel" destination="ysr-34-rEo" id="Xu7-Xr-mBb"/>
                                                         </connections>
                                                     </collectionViewCell>

--- a/iOS/AirbnbProject/AirbnbProject/Base.lproj/Main.storyboard
+++ b/iOS/AirbnbProject/AirbnbProject/Base.lproj/Main.storyboard
@@ -331,7 +331,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view alpha="0.64999997615814209" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3BC-kh-6Y9" userLabel="Dim View">
+                            <view alpha="0.65000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3BC-kh-6Y9" userLabel="Dim View">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
@@ -423,13 +423,14 @@
                                                                     <subviews>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KJr-IJ-mDV" userLabel="leftView">
                                                                             <rect key="frame" x="0.0" y="0.0" width="26.5" height="54"/>
-                                                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7y5-PP-lOc" userLabel="rightView">
                                                                             <rect key="frame" x="26.5" y="0.0" width="26.5" height="54"/>
-                                                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         </view>
                                                                     </subviews>
+                                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </stackView>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mdU-Cf-bpd" userLabel="Backbround View">
                                                                     <rect key="frame" x="0.0" y="0.0" width="53" height="54"/>
@@ -437,7 +438,6 @@
                                                                         <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
                                                                             <real key="value" value="0.0"/>
                                                                         </userDefinedRuntimeAttribute>
-                                                                        
                                                                     </userDefinedRuntimeAttributes>
                                                                 </view>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ysr-34-rEo">
@@ -449,6 +449,7 @@
                                                             </subviews>
                                                             <constraints>
                                                                 <constraint firstAttribute="bottom" secondItem="mdU-Cf-bpd" secondAttribute="bottom" id="3Ej-ud-6Lg"/>
+                                                                <constraint firstItem="KJr-IJ-mDV" firstAttribute="height" secondItem="JL3-ZT-tNU" secondAttribute="height" id="3cd-BF-cZW"/>
                                                                 <constraint firstAttribute="bottom" secondItem="QOF-og-lSW" secondAttribute="bottom" id="GIz-MJ-mI2"/>
                                                                 <constraint firstAttribute="trailing" secondItem="mdU-Cf-bpd" secondAttribute="trailing" id="Ihu-lv-T5G"/>
                                                                 <constraint firstItem="ysr-34-rEo" firstAttribute="centerX" secondItem="JL3-ZT-tNU" secondAttribute="centerX" id="Jam-Da-ovN"/>
@@ -457,6 +458,7 @@
                                                                 <constraint firstAttribute="trailing" secondItem="QOF-og-lSW" secondAttribute="trailing" id="ZX5-B1-tHm"/>
                                                                 <constraint firstItem="ysr-34-rEo" firstAttribute="centerY" secondItem="JL3-ZT-tNU" secondAttribute="centerY" id="dRd-Yu-wci"/>
                                                                 <constraint firstItem="mdU-Cf-bpd" firstAttribute="top" secondItem="JL3-ZT-tNU" secondAttribute="top" id="slo-in-9Wd"/>
+                                                                <constraint firstItem="7y5-PP-lOc" firstAttribute="height" secondItem="JL3-ZT-tNU" secondAttribute="height" id="to3-zb-MW7"/>
                                                                 <constraint firstItem="QOF-og-lSW" firstAttribute="leading" secondItem="JL3-ZT-tNU" secondAttribute="leading" id="xLd-Qi-kVY"/>
                                                             </constraints>
                                                         </collectionViewCellContentView>
@@ -519,7 +521,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="3BC-kh-6Y9" firstAttribute="bottom" secondItem="zlh-AR-jkL" secondAttribute="bottom" id="0AD-H9-SRY"/>
                             <constraint firstItem="L3t-jO-7SV" firstAttribute="centerY" secondItem="zlh-AR-jkL" secondAttribute="centerY" multiplier="0.95" id="Gcy-2X-yns"/>

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarCollectionViewManager.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarCollectionViewManager.swift
@@ -16,6 +16,7 @@ class CalenderCollectionViewManager {
     private let numberToAdjustFirstDay = 2
     private let numberToAdjustNextDay = 3
     private let firstDayPosition: Int
+    private let currentDate: Int
     
     let today: Int
     
@@ -28,6 +29,7 @@ class CalenderCollectionViewManager {
         
         self.firstDayPosition = firstWeekDay - numberToAdjustFirstDay
         self.today = indexPath.row - firstWeekDay + numberToAdjustNextDay
+        self.currentDate = currMonth.getTodayDate(date: currMonth)
     }
     
     func setCellHiddenStatus(indexPath: IndexPath) -> Bool {
@@ -36,5 +38,10 @@ class CalenderCollectionViewManager {
         } else {
             return false
         }
+    }
+    
+    func getYesterdayDatePosition() -> IndexPath {
+        let yesterdayDatePosition = IndexPath(row: currentDate + firstDayPosition - 1, section: 0)
+        return yesterdayDatePosition
     }
 }

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
@@ -13,6 +13,10 @@ class CalendarViewController: UIViewController {
     @IBOutlet weak var calendarCollectionView: UICollectionView!
     
     private let numberOfSection = 12
+    private var firstSelectedCellIndexPath: IndexPath?
+    private var selectedCells = [ IndexPath : DayCollectionViewCell ]()
+    private var selectedCellIndexPath = [IndexPath]()
+    private var selectedDates = [BookingDate]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -43,6 +47,9 @@ extension CalendarViewController: UICollectionViewDataSource {
         cell.isHidden = status
         cell.dayLabel.text = "\(manager.today)"
         
+        if indexPath.row < manager.today, cell.isHidden == false {
+            cell.isUserInteractionEnabled = false
+        }
         return cell
     }
     
@@ -52,6 +59,38 @@ extension CalendarViewController: UICollectionViewDataSource {
         header.monthYearLabel.text = "April 2020"
         
         return header
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if selectedCells[indexPath] == collectionView.cellForItem(at: indexPath){ // 선택된 셀을 다시 눌렀을 경우
+            selectedCells[indexPath]!.initializeBackgroundView()
+            selectedCellIndexPath.removeAll()
+            selectedCells[indexPath] = nil
+        } else {
+            if selectedCells.count < 2 {
+                let cell = collectionView.cellForItem(at: indexPath) as? DayCollectionViewCell
+                selectedCellIndexPath.append(indexPath)
+                selectedCells[indexPath] = cell
+                firstSelectedCellIndexPath = selectedCellIndexPath[0]
+                guard let firstSelectedCellIndexPath = firstSelectedCellIndexPath else {return}
+                
+                if firstSelectedCellIndexPath > indexPath {
+                    selectedCellIndexPath.remove(at: 0)
+                    selectedCells[firstSelectedCellIndexPath] = nil
+                }
+                
+            } else {
+                firstSelectedCellIndexPath = nil
+                selectedCells.forEach{$0.value.initializeBackgroundView()}
+                selectedCells = [:]
+                selectedCellIndexPath.removeAll()
+                selectedCellIndexPath.append(indexPath)
+            }
+        }
+        selectedCells.forEach{ selectedCell in
+            selectedCell.value.setupCellBackgroundView()
+            
+        }
     }
 }
 
@@ -66,4 +105,14 @@ extension CalendarViewController: UICollectionViewDelegateFlowLayout {
         let headerSize = CGSize(width:  calendarCollectionView.frame.size.width, height: calendarCollectionView.frame.size.width / 10)
         return headerSize
     }
+}
+
+struct BookingDate {
+    let checkInyear : String
+    let checkInmonth : String
+    let checkIndate : String
+    let checkOutyear : String
+    let checkOutmonth : String
+    let checkOutdate : String
+    
 }

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
@@ -63,13 +63,16 @@ extension CalendarViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        if selectedCells[indexPath] == collectionView.cellForItem(at: indexPath){ // 선택된 셀을 다시 눌렀을 경우
+        let cell = collectionView.cellForItem(at: indexPath) as? DayCollectionViewCell
+        
+        if selectedCells[indexPath] == collectionView.cellForItem(at: indexPath){
             selectedCells[indexPath]!.initializeBackgroundView()
             selectedCellIndexPath.removeAll()
             selectedCells[indexPath] = nil
         } else {
+            
             if selectedCells.count < 2 {
-                let cell = collectionView.cellForItem(at: indexPath) as? DayCollectionViewCell
+                
                 selectedCellIndexPath.append(indexPath)
                 selectedCells[indexPath] = cell
                 firstSelectedCellIndexPath = selectedCellIndexPath[0]
@@ -85,19 +88,22 @@ extension CalendarViewController: UICollectionViewDataSource {
                 selectedCells.forEach{$0.value.initializeBackgroundView()}
                 selectedCells = [:]
                 selectedCellIndexPath.removeAll()
+                if cell?.backgroundColor != .clear {
+                    cell?.initializeBackgroundView()
+                }
                 selectedCellIndexPath.append(indexPath)
             }
         }
         selectedCells.forEach{ selectedCell in
-            selectedCell.value.setupCellBackgroundView()
-            
+            selectedCell.value.updateSelectedCellBackgroundView()
         }
     }
 }
 
+
 extension CalendarViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let size = calendarCollectionView.frame.size.width / 9
+        let size = calendarCollectionView.bounds.width / 7.25
         let sizeForItem = CGSize(width: size, height: size)
         return sizeForItem
     }
@@ -115,5 +121,4 @@ struct BookingDate {
     let checkOutyear : String
     let checkOutmonth : String
     let checkOutdate : String
-    
 }

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
@@ -47,7 +47,8 @@ extension CalendarViewController: UICollectionViewDataSource {
         cell.isHidden = status
         cell.dayLabel.text = "\(manager.today)"
         
-        if indexPath.row < manager.today, cell.isHidden == false {
+        if indexPath < manager.getYesterdayDatePosition() {
+            cell.dayLabel.textColor = .lightGray
             cell.isUserInteractionEnabled = false
         }
         return cell

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/CalendarViewController.swift
@@ -88,9 +88,6 @@ extension CalendarViewController: UICollectionViewDataSource {
                 selectedCells.forEach{$0.value.initializeBackgroundView()}
                 selectedCells = [:]
                 selectedCellIndexPath.removeAll()
-                if cell?.backgroundColor != .clear {
-                    cell?.initializeBackgroundView()
-                }
                 selectedCellIndexPath.append(indexPath)
             }
         }

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/DayCollectionViewCell.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/DayCollectionViewCell.swift
@@ -18,17 +18,7 @@ class DayCollectionViewCell: UICollectionViewCell {
     static let identifier = "DayCollectionViewCell"
     
     var dateInfo: CellDateInfo?
-    
-    override var isSelected: Bool {
-        didSet {
-            if isSelected{
-                self.updateSelectedCellBackgroundView()
-            } else {
-                initializeBackgroundView()
-            }
-        }
-    }
-    
+        
     func updateSelectedCellBackgroundView() {
         cellBackgroundView.cornerRadius = cellBackgroundView.frame.size.width / 2
         dayLabel.textColor = .white
@@ -44,12 +34,16 @@ class DayCollectionViewCell: UICollectionViewCell {
     }
     
     override func prepareForReuse() {
+        
         dayLabel.text = nil
+        dayLabel.textColor = .black
         initializeBackgroundView()
         self.isUserInteractionEnabled = true
     }
     
     func updatePeriodCellBackgroundView() {
+        self.cellBackgroundView.cornerRadius = 0
+        dayLabel.textColor = .black
         self.cellBackgroundView.backgroundColor = UIColor(named: CustomColor.faintLightGray)
     }
     
@@ -63,6 +57,11 @@ class DayCollectionViewCell: UICollectionViewCell {
             leftBackgroundView.backgroundColor = UIColor(named: CustomColor.faintLightGray)
             rightBackgroundView.backgroundColor = .clear
         }
+    }
+    
+    func updateDisabledCell() {
+        self.dayLabel.textColor = .lightGray
+        self.isUserInteractionEnabled = false
     }
 }
 

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/DayCollectionViewCell.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/DayCollectionViewCell.swift
@@ -12,25 +12,67 @@ class DayCollectionViewCell: UICollectionViewCell {
     
     @IBOutlet weak var dayLabel: UILabel!
     @IBOutlet weak var cellBackgroundView: UIView!
-
+    @IBOutlet weak var leftBackgroundView: UIView!
+    @IBOutlet weak var rightBackgroundView: UIView!
+    
     static let identifier = "DayCollectionViewCell"
-
+    
     override var isSelected: Bool {
         didSet {
             if isSelected{
-                self.setupCellBackgroundView()
+                self.updateSelectedCellBackgroundView()
             } else {
                 initializeBackgroundView()
             }
         }
     }
     
-    func setupCellBackgroundView() {
+    func updateSelectedCellBackgroundView() {
+        let view = UIView()
+        let path = UIBezierPath(rect: view.frame)
+        path.move(to: CGPoint(x: self.frame.midX, y: self.frame.minY))
+        path.addLine(to: CGPoint(x: self.frame.maxX, y: self.frame.minY))
+        path.addLine(to: CGPoint(x: self.frame.maxX, y: self.frame.maxY))
+        path.addLine(to: CGPoint(x: self.frame.midX, y: self.frame.maxY))
+        path.close()
+        path.fill()
+        UIColor(named: "faintLightGray")?.setFill()
+        self.addSubview(view)
         cellBackgroundView.cornerRadius = cellBackgroundView.frame.size.width / 2
+        dayLabel.textColor = .white
         cellBackgroundView.backgroundColor = .darkGray
     }
     
     func initializeBackgroundView() {
+        dayLabel.textColor = .black
+        cellBackgroundView.cornerRadius = 0
         cellBackgroundView.backgroundColor = .clear
+        rightBackgroundView.backgroundColor = .clear
+        leftBackgroundView.backgroundColor = .clear
     }
+    
+    override func prepareForReuse() {
+        dayLabel.text = nil
+        initializeBackgroundView()
+        self.isUserInteractionEnabled = true
+    }
+    
+    func updatePeriodCellBackgroundView() {
+        self.backgroundColor = UIColor(named: "faintLightGray")
+    }
+    
+    func updateSideEndCellBackgroundView(sideDirection: Direction) {
+        switch sideDirection {
+        case .left:
+            leftBackgroundView.backgroundColor = .clear
+            rightBackgroundView.backgroundColor = UIColor(named: "flaterLightGray")
+        case .right:
+            leftBackgroundView.backgroundColor = UIColor(named: "flaterLightGray")
+            rightBackgroundView.backgroundColor = .clear
+        }
+    }
+}
+
+enum Direction {
+    case left, right
 }

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/DayCollectionViewCell.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/DayCollectionViewCell.swift
@@ -17,6 +17,8 @@ class DayCollectionViewCell: UICollectionViewCell {
     
     static let identifier = "DayCollectionViewCell"
     
+    var dateInfo: CellDateInfo?
+    
     override var isSelected: Bool {
         didSet {
             if isSelected{
@@ -28,16 +30,6 @@ class DayCollectionViewCell: UICollectionViewCell {
     }
     
     func updateSelectedCellBackgroundView() {
-        let view = UIView()
-        let path = UIBezierPath(rect: view.frame)
-        path.move(to: CGPoint(x: self.frame.midX, y: self.frame.minY))
-        path.addLine(to: CGPoint(x: self.frame.maxX, y: self.frame.minY))
-        path.addLine(to: CGPoint(x: self.frame.maxX, y: self.frame.maxY))
-        path.addLine(to: CGPoint(x: self.frame.midX, y: self.frame.maxY))
-        path.close()
-        path.fill()
-        UIColor(named: "faintLightGray")?.setFill()
-        self.addSubview(view)
         cellBackgroundView.cornerRadius = cellBackgroundView.frame.size.width / 2
         dayLabel.textColor = .white
         cellBackgroundView.backgroundColor = .darkGray
@@ -46,7 +38,7 @@ class DayCollectionViewCell: UICollectionViewCell {
     func initializeBackgroundView() {
         dayLabel.textColor = .black
         cellBackgroundView.cornerRadius = 0
-        cellBackgroundView.backgroundColor = .clear
+        self.cellBackgroundView.backgroundColor = .clear
         rightBackgroundView.backgroundColor = .clear
         leftBackgroundView.backgroundColor = .clear
     }
@@ -58,16 +50,17 @@ class DayCollectionViewCell: UICollectionViewCell {
     }
     
     func updatePeriodCellBackgroundView() {
-        self.backgroundColor = UIColor(named: "faintLightGray")
+        self.cellBackgroundView.backgroundColor = UIColor(named: CustomColor.faintLightGray)
     }
     
     func updateSideEndCellBackgroundView(sideDirection: Direction) {
+        dayLabel.textColor = .white
         switch sideDirection {
         case .left:
             leftBackgroundView.backgroundColor = .clear
-            rightBackgroundView.backgroundColor = UIColor(named: "flaterLightGray")
+            rightBackgroundView.backgroundColor = UIColor(named: CustomColor.faintLightGray)
         case .right:
-            leftBackgroundView.backgroundColor = UIColor(named: "flaterLightGray")
+            leftBackgroundView.backgroundColor = UIColor(named: CustomColor.faintLightGray)
             rightBackgroundView.backgroundColor = .clear
         }
     }
@@ -75,4 +68,14 @@ class DayCollectionViewCell: UICollectionViewCell {
 
 enum Direction {
     case left, right
+}
+
+struct CellDateInfo {
+    let year: Int
+    let month: Int
+    let day: Int
+}
+
+enum CustomColor {
+    static let faintLightGray = "faintLightGray"
 }

--- a/iOS/AirbnbProject/AirbnbProject/View/CalendarView/DayCollectionViewCell.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/CalendarView/DayCollectionViewCell.swift
@@ -11,6 +11,26 @@ import UIKit
 class DayCollectionViewCell: UICollectionViewCell {
     
     @IBOutlet weak var dayLabel: UILabel!
-    
+    @IBOutlet weak var cellBackgroundView: UIView!
+
     static let identifier = "DayCollectionViewCell"
+
+    override var isSelected: Bool {
+        didSet {
+            if isSelected{
+                self.setupCellBackgroundView()
+            } else {
+                initializeBackgroundView()
+            }
+        }
+    }
+    
+    func setupCellBackgroundView() {
+        cellBackgroundView.cornerRadius = cellBackgroundView.frame.size.width / 2
+        cellBackgroundView.backgroundColor = .darkGray
+    }
+    
+    func initializeBackgroundView() {
+        cellBackgroundView.backgroundColor = .clear
+    }
 }

--- a/iOS/AirbnbProject/AirbnbProject/View/Extension/DateExtension.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/Extension/DateExtension.swift
@@ -17,4 +17,10 @@ extension Date {
         components.day = 2
         return calendar.date(from: components)!
     }
+    
+    func getTodayDate(date: Date) -> Int {
+        let calendar = Calendar.current
+        let day = calendar.component(.day, from: date)
+        return day
+    }
 }


### PR DESCRIPTION
### 기능
1. 같은 날짜를 다시 선택했을 경우 선택해제
2. 체크인 날짜 선택 후 체크아웃 날짜를 선택하면 체크인 날짜, 체크아웃 날짜, 기간 날짜가 표시됨
3. 체크아웃 날짜가 체크인 날짜보다 이른 경우, 먼저 선택했던 날짜가 선택 해제되고 나중에 선택한 날짜가 체크인 날짜로 선택됨.
4. 체크인과 체크아웃이 같은 달이 아닌 경우에도 표시되도록 수정.
5. 스크롤을 이동했다가 다시 돌아가도 선택한 날짜 표시되도록 수정.
6. 이미 체크인, 체크아웃 날짜를 선택 후 추가적인 날짜 선택을 한 경우, 이전에 선택한 두 개의 날짜가 선택 해제되고 마지막에 선택한 날짜가 체크인 날짜로 선택됨.