### PR TITLE
[iOS] 메인메뉴 이미지 네트워크 통신 및 캐싱

### DIFF
--- a/iOS/AirbnbProject/AirbnbProject.xcodeproj/project.pbxproj
+++ b/iOS/AirbnbProject/AirbnbProject.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		6AEA9BBC2485484600F08724 /* CityPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEA9BBB2485484600F08724 /* CityPickerViewController.swift */; };
 		6AEA9BBE248549AA00F08724 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEA9BBD248549AA00F08724 /* LoginViewController.swift */; };
 		6AEA9BC1248551CF00F08724 /* PriceBarGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEA9BC0248551CF00F08724 /* PriceBarGraphView.swift */; };
+		AB23632B2489777E009FF6E2 /* AlamofireImage in Frameworks */ = {isa = PBXBuildFile; productRef = AB23632A2489777E009FF6E2 /* AlamofireImage */; };
 		AB5A3B902488C26100FDB1AB /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5A3B8F2488C26100FDB1AB /* Protocols.swift */; };
 		AB8ED7E9247694CF00B07D9F /* FilterHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AB8ED7E8247694CF00B07D9F /* FilterHeaderView.xib */; };
 		AB8ED7EB247694DB00B07D9F /* FilterFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AB8ED7EA247694DB00B07D9F /* FilterFooterView.xib */; };
@@ -119,6 +120,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6ACC3AFC248774D700E811F7 /* Alamofire in Frameworks */,
+				AB23632B2489777E009FF6E2 /* AlamofireImage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -247,6 +249,7 @@
 		AB8ED7C62473ACFC00B07D9F /* View */ = {
 			isa = PBXGroup;
 			children = (
+				6A334BE22472B5C900464B32 /* MainViewController.swift */,
 				6AEA9BBF2485519100F08724 /* PriceFilterView */,
 				6A301D222479094800D23B84 /* CalendarView */,
 				6A301D212479092000D23B84 /* FilterReusableView */,
@@ -268,7 +271,6 @@
 		AB8ED7C82473AD0C00B07D9F /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				6A334BE22472B5C900464B32 /* MainViewController.swift */,
 				6A334BE42472B5C900464B32 /* SavedAccomodationViewController.swift */,
 				6AEA9BBB2485484600F08724 /* CityPickerViewController.swift */,
 				6AEA9BBD248549AA00F08724 /* LoginViewController.swift */,
@@ -307,6 +309,7 @@
 			name = AirbnbProject;
 			packageProductDependencies = (
 				6ACC3AFB248774D700E811F7 /* Alamofire */,
+				AB23632A2489777E009FF6E2 /* AlamofireImage */,
 			);
 			productName = AirbnbProject;
 			productReference = 6A334BDB2472B5C900464B32 /* AirbnbProject.app */;
@@ -360,6 +363,7 @@
 			mainGroup = 6A334BD22472B5C900464B32;
 			packageReferences = (
 				6ACC3AFA248774D700E811F7 /* XCRemoteSwiftPackageReference "Alamofire" */,
+				AB2363292489777E009FF6E2 /* XCRemoteSwiftPackageReference "AlamofireImage" */,
 			);
 			productRefGroup = 6A334BDC2472B5C900464B32 /* Products */;
 			projectDirPath = "";
@@ -711,6 +715,14 @@
 				minimumVersion = 5.2.1;
 			};
 		};
+		AB2363292489777E009FF6E2 /* XCRemoteSwiftPackageReference "AlamofireImage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/AlamofireImage.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -718,6 +730,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6ACC3AFA248774D700E811F7 /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
+		};
+		AB23632A2489777E009FF6E2 /* AlamofireImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AB2363292489777E009FF6E2 /* XCRemoteSwiftPackageReference "AlamofireImage" */;
+			productName = AlamofireImage;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOS/AirbnbProject/AirbnbProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/AirbnbProject/AirbnbProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "2777659076fda38bd4e487739ee331c7a65b5924",
           "version": "5.2.1"
         }
+      },
+      {
+        "package": "AlamofireImage",
+        "repositoryURL": "https://github.com/Alamofire/AlamofireImage.git",
+        "state": {
+          "branch": null,
+          "revision": "3e8edbeb75227f8542aa87f90240cf0424d6362f",
+          "version": "4.1.0"
+        }
       }
     ]
   },

--- a/iOS/AirbnbProject/AirbnbProject/Base.lproj/Main.storyboard
+++ b/iOS/AirbnbProject/AirbnbProject/Base.lproj/Main.storyboard
@@ -415,7 +415,7 @@
                                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                 </collectionViewFlowLayout>
                                                 <cells>
-                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" reuseIdentifier="DayCollectionViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="DNG-Q0-piG" customClass="DayCollectionViewCell" customModule="AirbnbProject" customModuleProvider="target">
+                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="DayCollectionViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="DNG-Q0-piG" customClass="DayCollectionViewCell" customModule="AirbnbProject" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="50" width="53" height="54"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="JL3-ZT-tNU">

--- a/iOS/AirbnbProject/AirbnbProject/View/MainView/AccomodationInfoTableViewCell.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/MainView/AccomodationInfoTableViewCell.swift
@@ -19,8 +19,7 @@ class AccomodationInfoTableViewCell: UITableViewCell {
     @IBOutlet weak var titleLabel: UILabel!
     
     static let identifier = "AccomodationInfoTableViewCell"
-
-    var models: RoomInfo? // 배열이 아니라 하나
+    var models: RoomInfo?
         
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -31,12 +30,17 @@ class AccomodationInfoTableViewCell: UITableViewCell {
         super.setSelected(selected, animated: animated)
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.pageControl.currentPage = 0
+    }
+    
     static func nib() -> UINib {
         return UINib(nibName: identifier, bundle: nil)
     }
     
     private func setupAccomodationView() {
-        starRateAndReviewLabel.text = "⭐️\(models!.scores) (\(models!.reviews))"
+        starRateAndReviewLabel.text = "⭐️ \(models!.scores) (\(models!.reviews))"
         if !models!.is_super_host {
             superhostLabel.isHidden = true
         }
@@ -79,7 +83,18 @@ extension AccomodationInfoTableViewCell: UICollectionViewDataSource, UICollectio
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ThumbnailImageCollectionViewCell.identifier, for: indexPath) as! ThumbnailImageCollectionViewCell
-        // 여기서 이미지 URL 패치해서 이미지를 넣어줘야 함.
+        let imgUrl: String?
+        
+        if indexPath.row > (models?.image_lists.count)! - 1 {
+            imgUrl = models?.room_thumbnail
+        } else {
+            imgUrl = models?.image_lists[indexPath.row]
+        }
+        
+        DataUseCase.loadImg(manager: NetworkManager(), imgUrl: imgUrl!) { (image) in
+            cell.myImage.image = image ?? UIImage(systemName: "paperplane.fill")
+        }
+        
         return cell
     }
     
@@ -90,7 +105,7 @@ extension AccomodationInfoTableViewCell: UICollectionViewDataSource, UICollectio
     }
     
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        self.pageControl.numberOfPages = self.models?.image_lists.count ?? 0 + 1
+        self.pageControl.numberOfPages = (self.models?.image_lists.count ?? 0) + 1
         self.pageControl.pageIndicatorTintColor = .darkGray
         self.pageControl.currentPage = indexPath.row
     }

--- a/iOS/AirbnbProject/AirbnbProject/View/MainView/AccomodationInfoTableViewCell.xib
+++ b/iOS/AirbnbProject/AirbnbProject/View/MainView/AccomodationInfoTableViewCell.xib
@@ -44,8 +44,8 @@
                                         <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fSa-39-7i9">
-                                        <rect key="frame" x="94.5" y="0.0" width="91" height="18.5"/>
+                                    <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fSa-39-7i9">
+                                        <rect key="frame" x="94.5" y="0.0" width="86" height="18.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                                         <inset key="contentEdgeInsets" minX="2" minY="0.0" maxX="2" maxY="0.0"/>
                                         <state key="normal" title="SUPERHOST">
@@ -63,8 +63,8 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </button>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="label to give space" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cmc-ES-YRP" userLabel="spacing Label">
-                                        <rect key="frame" x="192.5" y="0.0" width="142.5" height="18.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="label to give space" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cmc-ES-YRP" userLabel="spacing Label">
+                                        <rect key="frame" x="187.5" y="0.0" width="147.5" height="18.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>

--- a/iOS/AirbnbProject/AirbnbProject/View/MainViewController.swift
+++ b/iOS/AirbnbProject/AirbnbProject/View/MainViewController.swift
@@ -127,7 +127,7 @@ extension MainViewController: UIScrollViewDelegate {
         let contentYoffset = scrollView.contentOffset.y
         let distanceFromBottom = scrollView.contentSize.height - contentYoffset
         if distanceFromBottom < height {
-            print("end of table view")
+            offset += 10
         }
     }
 }


### PR DESCRIPTION
### 구현한 것.
1. SPM에 AlamofireImage 추가
2. 이미지 다운로드는 AlamofierImage를 활용하고, 캐싱또한 AlamofireImage를 사용함.
3. 유니크한 cacheKey를 만들어 AutoPurgingImageCache()으로 인메모리 이미지 캐싱함.
4. 이미지를 로드할때 cacheKey로 해당 이미지를 찾아본 후 있으면 가져와서 보내주고, 없으면 네트워크 통신하여 이미지를 가지고 옴.

### 해결해야하는 것.
1. 페이지 컨트롤 재사용성 문제 : 다른 셀에서 두번째 숙소 이미지까지 보고 밑으로 스크롤하면 다른 셀에서도 두번째 화면부터 표시가 된다.